### PR TITLE
Update csrf.go

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -122,7 +122,7 @@ func GetToken(c *gin.Context) string {
 	session := sessions.Get(c)
 	secret := c.MustGet(csrfSecret).(string)
 
-	if t, err := c.Get(csrfToken); err == nil {
+	if t, ok := c.Get(csrfToken); ok {
 		return t.(string)
 	}
 


### PR DESCRIPTION
c.Get(key string) (interface{} bool), the error cannot be converted to bool, so using OK to fix it.
